### PR TITLE
Add bonepile after kanban API

### DIFF
--- a/API_WEB/Controllers/Repositories/Bonepile2Controller.cs
+++ b/API_WEB/Controllers/Repositories/Bonepile2Controller.cs
@@ -767,5 +767,150 @@ AND TO_DATE(TO_CHAR(SYSDATE, 'YYYY-MM-DD') || ' 10:59:59', 'YYYY-MM-DD HH24:MI:S
             return result;
         }
 
+        [HttpGet("bonepile-after-kanban")]
+        public async Task<IActionResult> BonepileAfterKanban()
+        {
+            try
+            {
+                var data = await ExecuteBonepileAfterKanbanQuery();
+                if (!data.Any())
+                {
+                    return NotFound(new { message = "Khong tim thay du lieu!!", count = 0 });
+                }
+
+                var sfgList = data.Select(d => d.SFG).Where(s => !string.IsNullOrEmpty(s)).ToList();
+
+                var scrapInfo = await _sqlContext.ScrapLists
+                    .Where(s => sfgList.Contains(s.SN))
+                    .Select(s => new { s.SN, s.ApplyTaskStatus, s.TaskNumber })
+                    .ToListAsync();
+
+                var scrapDict = scrapInfo.ToDictionary(s => s.SN, s => (s.ApplyTaskStatus, s.TaskNumber));
+
+                foreach (var item in data)
+                {
+                    if (scrapDict.TryGetValue(item.SFG, out var info))
+                    {
+                        if ((info.ApplyTaskStatus == 0 || info.ApplyTaskStatus == 1))
+                        {
+                            item.STATUS = string.IsNullOrEmpty(info.TaskNumber) ? "ScrapLackTask" : "ScrapHasTask";
+                        }
+                        else if (info.ApplyTaskStatus == 2)
+                        {
+                            item.STATUS = "WatitingScrap";
+                        }
+                        else if (info.ApplyTaskStatus == 3)
+                        {
+                            item.STATUS = "ApproveBGA";
+                        }
+                        else
+                        {
+                            item.STATUS = "RepairInRE";
+                        }
+                    }
+                    else
+                    {
+                        item.STATUS = "RepairInRE";
+                    }
+                }
+
+                return Ok(new { count = data.Count, data });
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, new { message = "Xay ra loi", error = ex.Message });
+            }
+        }
+
+        private async Task<List<BonepileAfterKanbanResult>> ExecuteBonepileAfterKanbanQuery()
+        {
+            var result = new List<BonepileAfterKanbanResult>();
+
+            await using var connection = new OracleConnection(_oracleContext.Database.GetDbConnection().ConnectionString);
+            await connection.OpenAsync();
+
+            string query = @"SELECT 
+    a.SERIAL_NUMBER AS SFG,
+    c.SERIAL_NUMBER AS FG,
+    a.MO_NUMBER,
+    a.MODEL_NAME,
+    b.PRODUCT_LINE,
+    a.WIP_GROUP AS WIP_GROUP_KANAN,
+    r107.WIP_GROUP AS WIP_GROUP_SFC,
+    c.WORK_TIME,
+    CASE 
+        WHEN NVL(r109_sfg.test_time, TO_DATE('1900-01-01','YYYY-MM-DD')) >= NVL(r109_fg.test_time, TO_DATE('1900-01-01','YYYY-MM-DD'))
+        THEN r109_sfg.test_code
+        ELSE r109_fg.test_code
+    END AS TEST_CODE,
+    CASE 
+        WHEN NVL(r109_sfg.test_time, TO_DATE('1900-01-01','YYYY-MM-DD')) >= NVL(r109_fg.test_time, TO_DATE('1900-01-01','YYYY-MM-DD'))
+        THEN r109_sfg.test_group
+        ELSE r109_fg.test_group
+    END AS TEST_GROUP,
+    CASE 
+        WHEN NVL(r109_sfg.test_time, TO_DATE('1900-01-01','YYYY-MM-DD')) >= NVL(r109_fg.test_time, TO_DATE('1900-01-01','YYYY-MM-DD'))
+        THEN r109_sfg.test_time
+        ELSE r109_fg.test_time
+    END AS TEST_TIME,
+    CASE 
+        WHEN NVL(r109_sfg.test_time, TO_DATE('1900-01-01','YYYY-MM-DD')) >= NVL(r109_fg.test_time, TO_DATE('1900-01-01','YYYY-MM-DD'))
+        THEN ce_sfg.error_desc
+        ELSE ce_fg.error_desc
+    END AS ERROR_CODE
+FROM SFISM4.Z_KANBAN_TRACKING_T a
+INNER JOIN SFIS1.C_MODEL_DESC_T b ON a.MODEL_NAME = b.MODEL_NAME
+LEFT JOIN (
+    SELECT * FROM (
+        SELECT t.*, ROW_NUMBER() OVER (PARTITION BY t.KEY_PART_SN ORDER BY t.WORK_TIME DESC) AS rn
+        FROM SFISM4.P_WIP_KEYPARTS_T t
+    ) WHERE rn = 1
+) c ON a.SERIAL_NUMBER = c.KEY_PART_SN
+LEFT JOIN (
+    SELECT * FROM (
+        SELECT t.*, ROW_NUMBER() OVER (PARTITION BY t.serial_number ORDER BY t.test_time DESC) AS rn
+        FROM SFISM4.R109 t
+    ) WHERE rn = 1
+) r109_sfg ON a.SERIAL_NUMBER = r109_sfg.serial_number
+LEFT JOIN (
+    SELECT * FROM (
+        SELECT t.*, ROW_NUMBER() OVER (PARTITION BY t.serial_number ORDER BY t.test_time DESC) AS rn
+        FROM SFISM4.R109 t
+    ) WHERE rn = 1
+) r109_fg ON c.SERIAL_NUMBER = r109_fg.serial_number
+LEFT JOIN SFIS1.C_ERROR_CODE_T ce_sfg ON r109_sfg.test_code = ce_sfg.error_code
+LEFT JOIN SFIS1.C_ERROR_CODE_T ce_fg ON r109_fg.test_code = ce_fg.error_code
+LEFT JOIN SFISM4.R107 r107 ON r107.SERIAL_NUMBER = a.SERIAL_NUMBER
+WHERE a.WIP_GROUP LIKE '%B36R'
+  AND b.model_serial != 'SWITCH'";
+
+            using (var command = new OracleCommand(query, connection))
+            {
+                using (var reader = await command.ExecuteReaderAsync())
+                {
+                    while (await reader.ReadAsync())
+                    {
+                        result.Add(new BonepileAfterKanbanResult
+                        {
+                            SFG = reader["SFG"].ToString(),
+                            FG = reader["FG"].ToString(),
+                            MO_NUMBER = reader["MO_NUMBER"].ToString(),
+                            MODEL_NAME = reader["MODEL_NAME"].ToString(),
+                            PRODUCT_LINE = reader["PRODUCT_LINE"].ToString(),
+                            WIP_GROUP_KANBAN = reader["WIP_GROUP_KANAN"].ToString(),
+                            WIP_GROUP_SFC = reader["WIP_GROUP_SFC"].ToString(),
+                            WORK_TIME = reader["WORK_TIME"] != DBNull.Value ? Convert.ToDateTime(reader["WORK_TIME"]) : (DateTime?)null,
+                            TEST_CODE = reader["TEST_CODE"].ToString(),
+                            TEST_GROUP = reader["TEST_GROUP"].ToString(),
+                            TEST_TIME = reader["TEST_TIME"] != DBNull.Value ? Convert.ToDateTime(reader["TEST_TIME"]) : (DateTime?)null,
+                            ERROR_CODE = reader["ERROR_CODE"].ToString()
+                        });
+                    }
+                }
+            }
+
+            return result;
+        }
+
     }
 }

--- a/API_WEB/Models/Bonepile/BonepileResult.cs
+++ b/API_WEB/Models/Bonepile/BonepileResult.cs
@@ -62,4 +62,22 @@
         public string DATA19 { get; set; }//NOTE
         public string STATUS { get; set; }
     }
+
+    // Result model for bonepile after kanban query
+    public class BonepileAfterKanbanResult
+    {
+        public string SFG { get; set; }
+        public string FG { get; set; }
+        public string MO_NUMBER { get; set; }
+        public string MODEL_NAME { get; set; }
+        public string PRODUCT_LINE { get; set; }
+        public string WIP_GROUP_KANBAN { get; set; }
+        public string WIP_GROUP_SFC { get; set; }
+        public DateTime? WORK_TIME { get; set; }
+        public string TEST_CODE { get; set; }
+        public string TEST_GROUP { get; set; }
+        public DateTime? TEST_TIME { get; set; }
+        public string ERROR_CODE { get; set; }
+        public string STATUS { get; set; }
+    }
 }


### PR DESCRIPTION
## Summary
- add a model for `BonepileAfterKanbanResult`
- implement `BonepileAfterKanban` API and query execution in `Bonepile2Controller`

## Testing
- `dotnet build API_WEB/API_WEB.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686dd086e670832b9cc20f2aac86cede