### PR TITLE
feat: add B36R export management

### DIFF
--- a/PESystem/Areas/Repositories/Views/Home/Index.cshtml
+++ b/PESystem/Areas/Repositories/Views/Home/Index.cshtml
@@ -33,7 +33,10 @@
         <div class="col-md-3">
             <div class="info-card">
                 <div class="card-body text-center">
-                    <h4 class="card-title fw-bold">B36R STATUS</h4>
+                    <div class="d-flex justify-content-between align-items-center mb-2">
+                        <h4 class="card-title fw-bold mb-0">B36R STATUS</h4>
+                        <i class="bi bi-gear" id="b36r-settings" style="cursor: pointer;"></i>
+                    </div>
                     <div class="d-flex align-items-center justify-content-between gap-2">
                         <div>
                             <span class="mb-0 text-primary fw-bold">Đã link</span><br />
@@ -66,6 +69,37 @@
                                 <th>MODEL_NAME</th>
                                 <th>EXPORT_DATE</th>
                                 <th>STATUS</th>
+                            </tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Modal quản lý Export -->
+    <div class="modal fade" id="exportModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Quản lý B36R Export</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="input-group mb-3">
+                        <input type="text" class="form-control" id="export-search-input" placeholder="Serial Number">
+                        <button class="btn btn-outline-secondary" id="export-search-btn" type="button">Search</button>
+                        <button class="btn btn-primary" id="export-add-btn" type="button">Add</button>
+                    </div>
+                    <table id="exportTable" class="table table-bordered table-striped" style="width:100%">
+                        <thead>
+                            <tr>
+                                <th>Serial Number</th>
+                                <th>Product Line</th>
+                                <th>Model Name</th>
+                                <th>Export Date</th>
+                                <th>Action</th>
                             </tr>
                         </thead>
                         <tbody></tbody>

--- a/PESystem/Areas/Repositories/Views/Shared/_Layout_Repo.cshtml
+++ b/PESystem/Areas/Repositories/Views/Shared/_Layout_Repo.cshtml
@@ -13,7 +13,6 @@
     <link href="~/lib/all-fa-icon/css/all.min.css" rel="stylesheet" />
     <script src="~/lib/gsap-particles/particles.min.js"></script>
     <script src="~/lib/gsap-particles/gsap.min.js"></script>
-    <script src="~/lib/datatable/datatables.fixedheader.min.js"></script>
 </head>
 
 <body>
@@ -126,6 +125,7 @@
     <script src="~/lib/sweetalert2/dist/sweetalert2.all.js"></script>
     <script src="~/lib/select2/dist/js/select2.full.min.js"></script>
     <script src="~/lib/datatable/jquery.datatables.min.js"></script>
+    <script src="~/lib/datatable/datatables.fixedheader.min.js"></script>
     <script src="~/lib/excel/xlsx.full.min.js"></script>
 
     @RenderSection("Scripts", required: false)


### PR DESCRIPTION
## Summary
- add CRUD endpoints for Export entities
- expose gear icon and modal for B36R export management
- implement client-side table with search and edit/delete actions

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_688d8d51be9c8329b9eb3ec2bc918c1e